### PR TITLE
add a label-sync config file

### DIFF
--- a/.github/plugin-repo-labels.yaml
+++ b/.github/plugin-repo-labels.yaml
@@ -1,0 +1,123 @@
+# A central configuration of labels that should get propagated across all repos with a label-sync workflow
+
+# General Purpose Labels
+#
+# Labels applicable for the general development workflow
+- name: major-feature
+  color: "003F00"
+  description: This PR introduces a major new feature
+  aliases:
+    - major-feature
+    - major-enhancement
+
+- name: major-bug
+  color: "FF1E0D"
+  description: This PR fixes a major bug
+
+- name: deprecated
+  color: "FEC111"
+  description: This PR marks a feature, function or other public API element as deprecated
+
+- name: removed
+  color: "d93f0b"
+  description: This PR removes a feature, function or other public API element
+
+- name: reverted
+  color: "f9bfa2"
+  description: This PR reverts a commit or multiple commits
+
+- name: breaking
+  color: "B60205"
+  description: This PR introduces breaking changes
+
+- name: revert
+  color: "F05032"
+  description: This PR reverts a commit
+
+- name: feature
+  color: "164916"
+  description: This PR or Issue requests or introduces a new feature
+  aliases:
+    - feature
+    - enhancement
+
+- name: bug
+  color: "d73a4a"
+  description: This PR or Issue describes or fixes something that isn't working
+  aliases:
+    - bug
+    - fix
+    - bugfix
+    - regression
+
+- name: documentation
+  color: "006699"
+  description: This PR or Issue aims to improve or add to documentation
+
+- name: tests
+  color: "25A162"
+  description: This PR adds or imposes tests (e.g. coverage, quality, ...)
+  aliases:
+    - test
+    - tests
+
+
+# Repository Maintenance Labels
+#
+# Labels used for PRs and Issues relevant for repo maintenance
+- name: wontfix
+  color: "a2eeef"
+  description: This Issue contains a request or 'bug' that wont be fixed (e.g. out-of-scope, not-an-issue, ...)
+
+- name: duplicate
+  color: "cfd3d7"
+  description: This Issue or PR is a duplicate of an existing Issue or PR
+
+- name: help-wanted
+  color: "008672"
+  description: This Issue or PR requires extra attention and/or requires external help
+  aliases:
+    - help wanted
+    - help-wanted
+
+- name: good-first-issue
+  color: "7057ff"
+  description: This Issue contains a requirement easy to be picked up by project newcomers
+  aliases:
+    - good first issue
+    - good-first-issue
+
+- name: invalid
+  color: "e4e669"
+  description: This Issue describes an invalid request or bug report
+
+- name: chore
+  color: "36566F"
+  description: This PR contains repository maintenance changes
+
+- name: dependencies
+  color: "1D76DB"
+  description: This PR updates or changes a dependency file
+
+- name: github_actions
+  color: "000000"
+  description: This PR updates or changes GH Actions used in this repo
+
+- name: nuget
+  color: "004880"
+  description: This PR updates or changes some NuGet dependencies
+
+- name: ci
+  color: "FFFF09"
+  description: This PR updates or changes something CI related
+  aliases:
+    - ci
+    - build
+
+
+# Release Drafter Labels
+#
+# these labels are used to control certain features of Release Drafter
+- name: skip-changelog
+  color: "e0e0e0"
+  description: This PR gets ignored by the Release Drafter workflow


### PR DESCRIPTION
### Description

This PR adds a config file defining a list of GH Labels that should be synced/shared across all of our org maintained plugin repos.
It comes in tandem with the CI PRs I recently opened for the plugin repos.

If I missed any obvious labels that are a must please let me know or add them. This can always be done later too, since the label-sync actions in the plugin repos is set to sync each month or when manually triggered.

### Change(s)

* adds a yaml config file readable by the [label-sync](https://github.com/EndBug/label-sync) Action 

### Issue(s)

* n/a