### PR TITLE
add autolabeler config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -55,11 +55,32 @@ exclude-labels:
   - skip-changelog
   - invalid
 
-template: |
+autolabeler:
+  - label: 'ci'
+    files:
+      - '.github/workflows/*'
+      - '.github/dependabot.yml'
+    branch:
+      - '(/ci){0,1}\/.+/'
+  - label: 'documentation'
+    files:
+      - '*.md'
+    branch:
+      - '(/docs){0,1}\/.+/'
+  - label: 'bugfix'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'feature'
+    branch:
+      - '/feature\/.+/'
+
+template: |-
   <!-- Optional: add a release summary here -->
   <!-- FIXME: [Plugin build can be downloaded here](<url to version download>) -->
-  
+
   ## :sparkles: What's New
-  
+
   $CHANGES
 


### PR DESCRIPTION
### Description

This PR extends the Release-Drafter config to enable auto labeling of PRs matching certain criteria. (See the [Docs](https://github.com/release-drafter/release-drafter#autolabeler) for more info on the matchers)

If you can think of any other category I have missed please feel free to ping me or add them yourself :wink: 

### Change(s)

* add a autolabeler config to the puglin release-drafter config

### Issue(s)

* n/a