### PR TITLE
chore: minor adaptations

### DIFF
--- a/.github/plugin-repo-labels.yaml
+++ b/.github/plugin-repo-labels.yaml
@@ -4,45 +4,45 @@
 #
 # Labels applicable for the general development workflow
 - name: major-feature
-  color: "003F00"
+  color: '003F00'
   description: This PR introduces a major new feature
   aliases:
     - major-feature
     - major-enhancement
 
 - name: major-bug
-  color: "FF1E0D"
+  color: 'FF1E0D'
   description: This PR fixes a major bug
 
 - name: deprecated
-  color: "FEC111"
+  color: 'FEC111'
   description: This PR marks a feature, function or other public API element as deprecated
 
 - name: removed
-  color: "d93f0b"
+  color: 'd93f0b'
   description: This PR removes a feature, function or other public API element
 
 - name: reverted
-  color: "f9bfa2"
+  color: 'f9bfa2'
   description: This PR reverts a commit or multiple commits
 
 - name: breaking
-  color: "B60205"
+  color: 'B60205'
   description: This PR introduces breaking changes
 
 - name: revert
-  color: "F05032"
+  color: 'F05032'
   description: This PR reverts a commit
 
 - name: feature
-  color: "164916"
+  color: '164916'
   description: This PR or Issue requests or introduces a new feature
   aliases:
     - feature
     - enhancement
 
 - name: bug
-  color: "d73a4a"
+  color: 'd73a4a'
   description: This PR or Issue describes or fixes something that isn't working
   aliases:
     - bug
@@ -51,11 +51,11 @@
     - regression
 
 - name: documentation
-  color: "006699"
+  color: '006699'
   description: This PR or Issue aims to improve or add to documentation
 
 - name: tests
-  color: "25A162"
+  color: '25A162'
   description: This PR adds or imposes tests (e.g. coverage, quality, ...)
   aliases:
     - test
@@ -66,58 +66,71 @@
 #
 # Labels used for PRs and Issues relevant for repo maintenance
 - name: wontfix
-  color: "a2eeef"
+  color: 'a2eeef'
   description: This Issue contains a request or 'bug' that wont be fixed (e.g. out-of-scope, not-an-issue, ...)
 
 - name: duplicate
-  color: "cfd3d7"
+  color: 'cfd3d7'
   description: This Issue or PR is a duplicate of an existing Issue or PR
 
 - name: help-wanted
-  color: "008672"
+  color: '008672'
   description: This Issue or PR requires extra attention and/or requires external help
   aliases:
     - help wanted
     - help-wanted
 
 - name: good-first-issue
-  color: "7057ff"
+  color: '7057ff'
   description: This Issue contains a requirement easy to be picked up by project newcomers
   aliases:
     - good first issue
     - good-first-issue
 
+- name: confirmed
+  color: 'a5e569'
+  description: This Issue describes a bug that has been confirmed by a org member
+
 - name: invalid
-  color: "e4e669"
+  color: 'e4e669'
   description: This Issue describes an invalid request or bug report
 
+- name: question
+  color: 'd876e3'
+  description: This Issue contains a question
+
 - name: chore
-  color: "36566F"
+  color: '36566F'
   description: This PR contains repository maintenance changes
 
 - name: dependencies
-  color: "1D76DB"
+  color: '1D76DB'
   description: This PR updates or changes a dependency file
 
-- name: github_actions
-  color: "000000"
+- name: github-actions
+  color: '000000'
   description: This PR updates or changes GH Actions used in this repo
+  aliases:
+    - github_actions
 
 - name: nuget
-  color: "004880"
+  color: '004880'
   description: This PR updates or changes some NuGet dependencies
 
 - name: ci
-  color: "FFFF09"
+  color: 'FFFF09'
   description: This PR updates or changes something CI related
   aliases:
     - ci
     - build
 
+- name: release-prep
+  color: 'e0e0e0'
+  description: This PR is a meta PR to prepare for the next release
 
 # Release Drafter Labels
 #
 # these labels are used to control certain features of Release Drafter
 - name: skip-changelog
-  color: "e0e0e0"
+  color: 'e0e0e0'
   description: This PR gets ignored by the Release Drafter workflow

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,52 +1,55 @@
 # Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
-name-template: "Version $NEXT_MAJOR_VERSION"
+name-template: 'Version $NEXT_MAJOR_VERSION'
 # Most plugins within the Jellyfin Org uses a single-digit versioning. Can be replaced by semver: $MAJOR.$MINOR.$PATCH
 # https://github.com/release-drafter/release-drafter#next-version-variables
-tag-template: "v$NEXT_MAJOR_VERSION"
-version-template: "$MAJOR"
-category-template: "### $TITLE"
+tag-template: 'v$NEXT_MAJOR_VERSION'
+version-template: '$MAJOR'
+category-template: '### $TITLE'
 
 # Emoji reference: https://gitmoji.carloscuesta.me/
 categories:
-  - title: ":boom: Breaking changes"
+  - title: ':boom: Breaking changes'
     labels:
       - breaking
-  - title: ":fire: Removed"
+  - title: ':fire: Removed'
     labels:
       - removed
-  - title: ":rewind: Reverted Changes"
+  - title: ':rewind: Reverted Changes'
     labels:
       - revert
       - reverted
-  - title: ":rocket: Major features and improvements"
+  - title: ':rocket: Major features and improvements'
     labels:
       - major-enhancement
-  - title: ":ambulance: Major bug fixes"
+  - title: ':ambulance: Major bug fixes'
     labels:
       - major-bug
-  - title: ":wastebasket:️ Deprecated"
+  - title: ':wastebasket:️ Deprecated'
     label: deprecated
-  - title: ":tada: New features and improvements"
+  - title: ':tada: New features and improvements'
     labels:
       - enhancement
       - feature
-  - title: ":bug: Bug Fixes"
+  - title: ':bug: Bug Fixes'
     labels:
       - bug
       - fix
       - bugfix
       - regression
-  - title: ":arrow_up: Dependency updates"
+  - title: ':arrow_up: Dependency updates'
     labels:
       - dependencies # Default label used by Dependabot
-  - title: ":construction_worker: CI & build changes"
+  - title: ':construction_worker: CI & build changes'
     labels:
       - ci
       - build
-  - title: ":memo: Documentation updates"
+  - title: ':gear: Code or Repo Maintenance'
+    labels:
+      - chore
+  - title: ':memo: Documentation updates'
     labels:
       - documentation
-  - title: ":white_check_mark: Tests"
+  - title: ':white_check_mark: Tests'
     labels:
       - test
       - tests
@@ -56,23 +59,28 @@ exclude-labels:
   - invalid
 
 autolabeler:
-  - label: 'ci'
+  - label: ci
     files:
       - '.github/workflows/*'
       - '.github/dependabot.yml'
     branch:
-      - '(/ci){0,1}\/.+/'
-  - label: 'documentation'
+      - '/ci\/.+/'
+  - label: documentation
     files:
       - '*.md'
     branch:
-      - '(/docs){0,1}\/.+/'
-  - label: 'bugfix'
+      - '/docs?\/.+/'
+  - label: bug
     branch:
       - '/fix\/.+/'
     title:
       - '/fix/i'
-  - label: 'feature'
+  - label: chore
+    branch:
+      - '/chore\/.+/'
+    title:
+      - '/chore/i'
+  - label: feature
     branch:
       - '/feature\/.+/'
 


### PR DESCRIPTION
### Description

Well this fixes some of my errors of earlier PRs and updates the label config and Release Drafter config slightly.

WARNING: If we want to include the `github_actions` update to unify the formats we need to update the dependabot configs of the plugins using the label sync

### Change(s)

* add the missing plugin labels `question`, `confirmed` and `release-prep`
* updates `github_actions` to `github-actions` (WARNING: we will have to update the label in the dependant configs of ALL plugin repos referencing this config)
* add a `chore` category to the Release Drafter config
* updates and fixes the auto labeler config

### Issue(s)

* n/a