### PR TITLE
fix: dependcy label for release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -39,6 +39,7 @@ categories:
   - title: ':arrow_up: Dependency updates'
     labels:
       - dependencies # Default label used by Dependabot
+      - dependency
   - title: ':construction_worker: CI & build changes'
     labels:
       - ci


### PR DESCRIPTION
followup to #11, since it messes with the draft category matcher