### PR TITLE
ci: make workflow templates more modular

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,16 @@
 on:
   workflow_call:
+    inputs:
+      dotnet-version:
+        required: false
+        default: "6.0.x"
+        description: "The .NET version to setup for the build"
+        type: string
+      dotnet-target:
+        required: false
+        default: "net6.0"
+        description: "The .NET target to set for JPRM"
+        type: string
 
 jobs:
   build:
@@ -11,13 +22,13 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1.9.0
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: "${{ inputs.dotnet-version }}"
 
       - name: Build Jellyfin Plugin
         uses: oddstr13/jellyfin-plugin-repository-manager@v0.4.2
         id: jprm
         with:
-          dotnet-target: net6.0
+          dotnet-target: "${{ inputs.dotnet-target }}"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -11,6 +11,16 @@ on:
         required: false
         default: false
         type: boolean
+      commiter-name:
+        required: false
+        default: "jellyfin-bot"
+        description: "This param overwrites the version bump committing git user.name"
+        type: string
+      commiter-email:
+        required: false
+        default: "team@jellyfin.org"
+        description: "This param overwrites the version bump committing git user.email"
+        type: string
 
 
 jobs:
@@ -49,7 +59,7 @@ jobs:
 
       - name: Commit bump
         run: |-
-          git config user.name "jellyfin-bot"
-          git config user.email "team@jellyfin.org"
+          git config user.name "${{ inputs.commiter-name }}"
+          git config user.email "${{ inputs.commiter-email }}"
           git commit -am "chore: prepare for next release (v${NEXT_VERSION})"
           git push origin ${GITHUB_REF}

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -4,6 +4,16 @@ on:
       repository-name:
         required: true
         type: string
+      commiter-name:
+        required: false
+        default: "jellyfin-bot"
+        description: "This param overwrites the version bump committing git user.name"
+        type: string
+      commiter-email:
+        required: false
+        default: "team@jellyfin.org"
+        description: "This param overwrites the version bump committing git user.email"
+        type: string
     secrets:
       token:
         required: true
@@ -52,8 +62,8 @@ jobs:
       - name: Commit Changes
         if: ${{ env.HAS_CHANGES == 'true' }}
         run: |-
-          git config user.name "jellyfin-bot"
-          git config user.email "team@jellyfin.org"
+          git config user.name "${{ inputs.commiter-name }}"
+          git config user.email "${{ inputs.commiter-email }}"
           git checkout -b prepare-${{ env.VERSION }}
           git commit -am "Bump version to ${{ env.VERSION }}"
           git push -f origin prepare-${{ env.VERSION }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,16 @@ on:
         required: false
         default: false
         type: boolean
+      dotnet-version:
+        required: false
+        default: "6.0.x"
+        description: "The .NET version to setup for the build"
+        type: string
+      dotnet-target:
+        required: false
+        default: "net6.0"
+        description: "The .NET target to set for JPRM"
+        type: string
     secrets:
       deploy-host:
         required: true
@@ -27,13 +37,13 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1.9.0
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: "${{ inputs.dotnet-version }}"
 
       - name: Build Jellyfin Plugin
         uses: oddstr13/jellyfin-plugin-repository-manager@v0.4.2
         id: jprm
         with:
-          dotnet-target: net6.0
+          dotnet-target: "${{ inputs.dotnet-target }}"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2.3.1

--- a/.github/workflows/scan-codeql.yaml
+++ b/.github/workflows/scan-codeql.yaml
@@ -4,6 +4,11 @@ on:
       repository-name:
         required: true
         type: string
+      dotnet-version:
+        required: false
+        default: "6.0.x"
+        description: "The .NET version to setup for the build"
+        type: string
 
 jobs:
   analyze:
@@ -23,7 +28,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1.9.0
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: "${{ inputs.dotnet-version }}"
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,11 @@
 on:
   workflow_call:
+    inputs:
+      dotnet-version:
+        required: false
+        default: "6.0.x"
+        description: "The .NET version to setup for the build"
+        type: string
 
 jobs:
   test:
@@ -11,7 +17,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1.9.0
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: "${{ inputs.dotnet-version }}"
 
       - name: Install dependencies
         run: dotnet restore


### PR DESCRIPTION
### Description

This PR expose more parameters for users to overwrite if they have a need for it.
Otherwise all new parameters are set to reasonable defaults for org internal use.

### Changes

* build workflow template
  * expose .NET version used for the build
  * expose .NET target used by JPRM
* bump-version workflow template
  * expose commiter-name and -email so non org users could set their own 'bot-users'
* changlog workflow template
  * expose commiter-name and -email so non org users could set their own 'bot-users'
* publish workflow template
  * expose .NET version used for the build
  * expose .NET target used by JPRM
* codeQL workflow template
  * expose .NET version used for the build
* test workflow template
  * expose .NET version used for the build

### Issues

* n/a