### PR TITLE
fix yq setup action

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       - name: Setup YQ
-        uses: chrisdickinson/setup-yq@v1.0.0
+        uses: chrisdickinson/setup-yq@v1.0.1
         with:
           yq-version: v4.16.2
 

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -32,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.token }}
 
       - name: Setup YQ
-        uses: chrisdickinson/setup-yq@v1.0.0
+        uses: chrisdickinson/setup-yq@v1.0.1
         with:
           yq-version: v4.16.2
 


### PR DESCRIPTION
well discovered that ssetup-yq 1.0.0 doesn't work with the first Plugin migrated over, so this fixes that by using a working version