### PR TITLE
fix: prepare-branch naming

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Set-up Environment
         run: |-
+          TAG="${{ steps.draft.outputs.tag_name }}"
+          echo "VERSION=${TAG#v}" >> $GITHUB_ENV
           cat << EOF | grep -P '^([*-] |###)' > cl.md
           ${{ steps.draft.outputs.body }}
           EOF


### PR DESCRIPTION
removed the version environment variable without noticing the remaining use :man_facepalming: