### PR TITLE
fix: add missing HEAD to git refspec

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -67,4 +67,4 @@ jobs:
           git config user.name "${{ inputs.commiter-name }}"
           git config user.email "${{ inputs.commiter-email }}"
           git commit -am "chore: prepare for next release (v${NEXT_VERSION})"
-          git push origin "refs/heads/${{ inputs.default-branch }}"
+          git push origin "HEAD:refs/heads/${{ inputs.default-branch }}"


### PR DESCRIPTION
this hopefully fixes the final issue with the git push of the version bump workflow