### PR TITLE
fix: bump version for protected branches

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -38,11 +38,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2.4.0
 
-      - name: Setup YQ
-        uses: chrisdickinson/setup-yq@v1.0.1
-        with:
-          yq-version: v4.16.2
-
       - name: Read current version
         run: |-
           echo "CURRENT_VERSION=$(yq eval '.version' build.yaml)"

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,3 +1,5 @@
+# DEPRECATED: Please use / rely on the changelog workflow as that works with protected branches
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - name: Update Draft
-        uses: release-drafter/release-drafter@v5.16.1
+        uses: release-drafter/release-drafter@v5.19.0
         id: draft
         env:
           GITHUB_TOKEN: ${{ secrets.token }}
@@ -59,7 +59,16 @@ jobs:
       - name: Update build.yaml
         if: ${{ env.HAS_CHANGES == 'true' }}
         run: |-
-          yq eval '.targetAbi = env(ABI_VERSION) | .changelog = strenv(CHANGELOG) | .changelog style="literal"' -i build.yaml
+          if [[ -f Directory.Build.props ]]; then
+            # https://stackoverflow.com/a/57510475
+            # https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2022
+            sed -i Directory.Build.props \
+              -e "s;<Version>.*</Version>;<Version>${VERSION}.0.0.0</Version>;" \
+              -e "s;<AssemblyVersion>.*</AssemblyVersion>;<AssemblyVersion>${VERSION}.0.0.0</AssemblyVersion>;" \
+              -e "s;<FileVersion>.*</FileVersion>;<FileVersion>${VERSION}.0.0.0</FileVersion>;"
+          fi
+
+          yq eval '.version = env(VERSION) | .targetAbi = env(ABI_VERSION) | .changelog = strenv(CHANGELOG) | .changelog style="literal"' -i build.yaml
 
       - name: Commit Changes
         if: ${{ env.HAS_CHANGES == 'true' }}

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -31,11 +31,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.token }}
 
-      - name: Setup YQ
-        uses: chrisdickinson/setup-yq@v1.0.1
-        with:
-          yq-version: v4.16.2
-
       - name: Set-up Environment
         run: |-
           TAG="${{ steps.draft.outputs.tag_name }}"


### PR DESCRIPTION
### Description

Sorry for taking so long with this simple fix, but live got in the way and motivation bit hard to build up.
This PR will reintroduce the version bump to the 'changelog' workflow that then gets part of the generated PRs.

### Changes

* deprecate the bump-version workflow
* re-add bumping to the changelog workflow
* remove obsolete yq-setup, since its now included in the GitHub Actions Virtual Environments 

### Issues

* n/a
* Matrix Dev chat comment