### PR TITLE
refactor: renovate config and submodule cleanup

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,23 +1,20 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "github>jellyfin/.github//renovate-presets/default",
+    ":dependencyDashboard"
   ],
-  "labels": ["dependencies"],
   "packageRules": [
     {
-      "matchManagers": ["github-actions"],
-      "addLabels": ["github_actions"]
-    },
-    {
+      "description": "Auto update the Git submodules of this repository and auto merge the branches",
       "matchManagers": ["git-submodules"],
       "addLabels": ["git-submodules"],
       "automerge": true,
+      "ignoreTests": true,
       "automergeType": "branch"
     }
   ],
   "git-submodules": {
     "enabled": true
-  },
-  "timezone": "Etc/UTC",
-  "schedule": ["before 2am"]
+  }
 }

--- a/.gitmodules
+++ b/.gitmodules
@@ -102,7 +102,3 @@
 	path = jellyfin-plugin-vgmdb
 	url = https://github.com/jellyfin/jellyfin-plugin-vgmdb.git
 	branch = master
-[submodule "jellyfin-plugin-id3"]
-	path = jellyfin-plugin-id3
-	url = https://github.com/jellyfin/jellyfin-plugin-id3.git
-	branch = master


### PR DESCRIPTION
### Description

This PR aims to utilize the ORG global Renovate presets and only customize the bits relevant fro this repo.

### Changes

* use the ORG's Renovate global preset
* remove id3 plugin from submodules (that already no longer exists?)
* (fix automerge)

### Issues

* Matrix Chat (hanging submodule PRs)