### PR TITLE
refactor: cleanup plugin repo label config

### DIFF
--- a/.github/plugin-repo-labels.yaml
+++ b/.github/plugin-repo-labels.yaml
@@ -23,16 +23,14 @@
   description: This PR removes a feature, function or other public API element
 
 - name: reverted
-  color: 'f9bfa2'
+  color: 'f05032'
   description: This PR reverts a commit or multiple commits
+  aliases:
+    - revert
 
 - name: breaking
   color: 'B60205'
   description: This PR introduces breaking changes
-
-- name: revert
-  color: 'F05032'
-  description: This PR reverts a commit
 
 - name: feature
   color: '164916'
@@ -73,14 +71,14 @@
   color: 'cfd3d7'
   description: This Issue or PR is a duplicate of an existing Issue or PR
 
-- name: help-wanted
+- name: help wanted
   color: '008672'
   description: This Issue or PR requires extra attention and/or requires external help
   aliases:
     - help wanted
     - help-wanted
 
-- name: good-first-issue
+- name: good first issue
   color: '7057ff'
   description: This Issue contains a requirement easy to be picked up by project newcomers
   aliases:
@@ -107,9 +105,12 @@
   color: '36566F'
   description: This PR contains repository maintenance changes
 
-- name: dependency
+- name: dependencies
   color: '1D76DB'
   description: This PR updates or changes a dependency file
+  aliases:
+    - dependency
+    - dependencies
 
 - name: github-actions
   color: '000000'


### PR DESCRIPTION
### Description

I noticed that my original configuration for the shared labels was quite suboptimal in certain areas just for format consistency sake.
This PR aims to rectify this error and generally cleans up some label configurations. 

### Changes

* stop overwriting GitHub's default labels (such as `good first issue`)
* unify `reverted` label
* fix `dependencies` label 

### Issues

* overwrote GitHub 'default' labels
* unnecessarily cleaned up dependency labels