### PR TITLE
Update paths for new repo layout

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -86,7 +86,7 @@ jobs:
           key: ${{ secrets.deploy-key }}
           script_stop: true
           script: |-
-            mkdir -p "/srv/repository/incoming/plugin/${{ github.repository }}/${{ inputs.version }}" || exit 1
+            mkdir -p "/srv/incoming/plugin/${{ github.repository }}/${{ inputs.version }}" || exit 1
 
       - name: Upload Jellyfin Plugin Repository Assets
         uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823 # tag=5.2
@@ -94,7 +94,7 @@ jobs:
         with:
           switches: -vrptz
           path: ./*.zip
-          remote_path: /srv/repository/incoming/plugin/${{ github.repository }}/${{ inputs.version }}
+          remote_path: /srv/incoming/plugin/${{ github.repository }}/${{ inputs.version }}
           remote_host: ${{ secrets.deploy-host }}
           remote_user: ${{ secrets.deploy-user }}
           remote_key: ${{ secrets.deploy-key }}
@@ -105,8 +105,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(github.repository, 'jellyfin/') }}
     env:
-      JELLYFIN_REPO: "/srv/repository/mirror/releases/plugin/manifest-stable.json"
-      JELLYFIN_REPO_URL: "https://repo.jellyfin.org/releases/plugin/"
+      JELLYFIN_REPO: "/srv/repository/main/plugin/manifest-stable.json"
+      JELLYFIN_REPO_URL: "https://repo.jellyfin.org/files/plugin/"
     steps:
       - name: Update Plugin Manifest
         uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
@@ -118,10 +118,10 @@ jobs:
           envs: JELLYFIN_REPO,JELLYFIN_REPO_URL
           script: |-
             lockfile="/run/lock/jprm.lock"
-            pushd "/srv/repository/incoming/plugin/${{ github.repository }}/${{ inputs.version }}" || exit 1
+            pushd "/srv/incoming/plugin/${{ github.repository }}/${{ inputs.version }}" || exit 1
             (
                 flock -x 300
                 jprm --verbosity=debug repo add --url="${JELLYFIN_REPO_URL}" "${JELLYFIN_REPO}" ./*.zip || exit 1
             ) 300>${lockfile}
             popd || exit 1
-            rm -r "/srv/repository/incoming/plugin/${{ github.repository }}/${{ inputs.version }}" || exit 1
+            rm -r "/srv/incoming/plugin/${{ github.repository }}/${{ inputs.version }}" || exit 1


### PR DESCRIPTION
Can be merged whenever, but anything built until the repository cutover will not yet be visible as this is a clone of the current repo layout.