### PR TITLE
Move unstable plugins to dedicated directory

### DIFF
--- a/.github/workflows/publish-unstable.yaml
+++ b/.github/workflows/publish-unstable.yaml
@@ -105,8 +105,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(github.repository, 'jellyfin/') }}
     env:
-      JELLYFIN_REPO: "/srv/repository/main/plugin/manifest-unstable.json"
-      JELLYFIN_REPO_URL: "https://repo.jellyfin.org/files/plugin/"
+      JELLYFIN_REPO: "/srv/repository/main/plugin-unstable/manifest.json"
+      JELLYFIN_REPO_URL: "https://repo.jellyfin.org/files/plugin-unstable/"
     steps:
       - name: Update Plugin Manifest
         uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(github.repository, 'jellyfin/') }}
     env:
-      JELLYFIN_REPO: "/srv/repository/main/plugin/manifest-stable.json"
+      JELLYFIN_REPO: "/srv/repository/main/plugin/manifest.json"
       JELLYFIN_REPO_URL: "https://repo.jellyfin.org/files/plugin/"
     steps:
       - name: Update Plugin Manifest


### PR DESCRIPTION
Avoids colocating stable and unstable together and resets from the
previous ancient attempt.

Also changes the manifest file for stable to match (just "manifest.json") with a symlink handling the compatibility there.